### PR TITLE
ci: add Mobile Release aggregated workflow and platform jobs

### DIFF
--- a/.github/workflows/android_release.yml
+++ b/.github/workflows/android_release.yml
@@ -1,0 +1,369 @@
+name: Android Release (AAB)
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_id:
+        description: "Custom applicationId (optional)"
+        required: false
+        default: "app.mhb.preview"
+      package_name:
+        description: "Google Play package name (e.g., app.mhb.preview)"
+        required: false
+        default: "app.mhb.preview"
+      track:
+        description: "Play track to upload (internal, alpha, beta, production)"
+        required: false
+        default: "internal"
+      build_number:
+        description: "Build number (optional). Defaults to GitHub run number if empty."
+        required: false
+        default: ""
+      release_notes:
+        description: "Release notes/changelog (optional)"
+        required: false
+        default: ""
+      upload:
+        description: "Upload to Google Play after build?"
+        required: false
+        default: "false"
+      preflight:
+        description: "Run format/analyze/tests before build?"
+        required: false
+        default: "false"
+      environment:
+        description: "GitHub Environment to run upload job (e.g., beta, production)"
+        required: false
+        default: "beta"
+      sentry_upload:
+        description: "Upload ProGuard mapping to Sentry?"
+        required: false
+        default: "false"
+      sentry_org:
+        description: "Sentry organization slug (if uploading symbols)"
+        required: false
+        default: ""
+      sentry_project:
+        description: "Sentry project slug (if uploading symbols)"
+        required: false
+        default: ""
+      sentry_release:
+        description: "Sentry release version (defaults to <package_name>@<build_number>)"
+        required: false
+        default: ""
+      crashlytics_upload:
+        description: "Upload Crashlytics ProGuard mapping? (requires Crashlytics plugin configured)"
+        required: false
+        default: "false"
+  workflow_call:
+    inputs:
+      app_id:
+        required: false
+        type: string
+        default: "app.mhb.preview"
+      package_name:
+        required: false
+        type: string
+        default: "app.mhb.preview"
+      track:
+        required: false
+        type: string
+        default: "internal"
+      build_number:
+        required: false
+        type: string
+        default: ""
+      release_notes:
+        required: false
+        type: string
+        default: ""
+      upload:
+        required: false
+        type: string
+        default: "false"
+      preflight:
+        required: false
+        type: string
+        default: "false"
+      environment:
+        required: false
+        type: string
+        default: "beta"
+      sentry_upload:
+        required: false
+        type: string
+        default: "false"
+      sentry_org:
+        required: false
+        type: string
+        default: ""
+      sentry_project:
+        required: false
+        type: string
+        default: ""
+      sentry_release:
+        required: false
+        type: string
+        default: ""
+      crashlytics_upload:
+        required: false
+        type: string
+        default: "false"
+
+jobs:
+  build_aab:
+    name: Build signed AAB
+    runs-on: ubuntu-latest
+    env:
+      # Map workflow input to Gradle property via ORG_GRADLE_PROJECT_ prefix
+      ORG_GRADLE_PROJECT_APP_ID: ${{ inputs.app_id || github.event.inputs.app_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Flutter SDK + Android SDK
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: '3.32.8'
+          android: true
+
+      - name: Flutter version
+        run: flutter --version
+
+      - name: Cache Pub (Dart/Flutter packages)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('ai_buddy_web/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Restore keystore from secret
+        shell: bash
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          set -e
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "::warning::ANDROID_KEYSTORE_BASE64 not set. Build will fall back to debug signing (not Play-ready)."
+          else
+            mkdir -p ai_buddy_web/android/app
+            echo "$ANDROID_KEYSTORE_BASE64" | base64 -d > ai_buddy_web/android/app/upload-keystore.jks
+            ls -lh ai_buddy_web/android/app/upload-keystore.jks
+          fi
+
+      - name: Install Flutter deps
+        working-directory: ai_buddy_web
+        run: flutter pub get
+
+      - name: Preflight - format check
+        if: ${{ (inputs.preflight || github.event.inputs.preflight) == 'true' }}
+        working-directory: ai_buddy_web
+        run: |
+          set -e
+          # Format only relevant Dart sources; exclude backups/exports to keep CI stable
+          FOUND=$(find . -type f -name "*.dart" \
+            -not -path "./lib/screens/quest_screen_backup/*" \
+            -not -path "./lib/screens/quest_screen/*" \
+            -not -path "./lib/dhiwise_export/*" \
+            -not -path "./lib/dhiwise/*" \
+            -not -path "./lib/dhiwise/**/backup/*" -print)
+          if [ -z "$FOUND" ]; then
+            echo "No Dart files to format"; exit 0;
+          fi
+          printf "%s\n" "$FOUND" | tr '\n' '\0' | xargs -0 dart format --output=none --set-exit-if-changed
+
+      - name: Preflight - analyze
+        if: ${{ (inputs.preflight || github.event.inputs.preflight) == 'true' }}
+        working-directory: ai_buddy_web
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Preflight - tests
+        if: ${{ (inputs.preflight || github.event.inputs.preflight) == 'true' }}
+        working-directory: ai_buddy_web
+        run: |
+          if [ -d test ]; then
+            flutter test -r expanded
+          else
+            echo "No tests/ directory found. Skipping flutter test."
+          fi
+
+      - name: Build signed AAB via Flutter
+        working-directory: ai_buddy_web
+        env:
+          # Map repo secrets to our build.gradle env overrides
+          STORE_FILE: ${{ github.workspace }}/ai_buddy_web/android/app/upload-keystore.jks
+          STORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          # Version code for Gradle
+          ORG_GRADLE_PROJECT_VERSION_CODE: ${{ inputs.build_number || github.event.inputs.build_number }}
+        run: |
+          set -e
+          BN="${{ inputs.build_number || github.event.inputs.build_number }}"
+          if [ -z "$BN" ]; then BN="$GITHUB_RUN_NUMBER"; fi
+          echo "Using build number: $BN"
+          flutter build appbundle --release --no-tree-shake-icons --build-number "$BN"
+
+      - name: Upload ProGuard mapping to Sentry (optional)
+        if: ${{ (inputs.sentry_upload || github.event.inputs.sentry_upload) == 'true' }}
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ inputs.sentry_org || github.event.inputs.sentry_org }}
+          SENTRY_PROJECT: ${{ inputs.sentry_project || github.event.inputs.sentry_project }}
+          PKG: ${{ inputs.package_name || github.event.inputs.package_name }}
+          BN: ${{ inputs.build_number || github.event.inputs.build_number }}
+          SENTRY_RELEASE_INPUT: ${{ inputs.sentry_release || github.event.inputs.sentry_release }}
+        run: |
+          set -e
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_ORG" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "::warning::Missing Sentry config; skipping upload"; exit 0; fi
+          REL="$SENTRY_RELEASE_INPUT"
+          if [ -z "$REL" ]; then
+            BNV="$BN"; [ -z "$BNV" ] && BNV="$GITHUB_RUN_NUMBER"
+            REL="${PKG}@${BNV}"
+          fi
+          echo "Using Sentry release: $REL"
+          curl -sL https://sentry.io/get-cli/ | bash
+          MAP1="ai_buddy_web/android/app/build/outputs/mapping/release/mapping.txt"
+          MAP2="ai_buddy_web/build/app/outputs/mapping/release/mapping.txt"
+          MAP=""
+          [ -f "$MAP1" ] && MAP="$MAP1"
+          [ -z "$MAP" ] && [ -f "$MAP2" ] && MAP="$MAP2"
+          if [ -z "$MAP" ]; then echo "::warning::mapping.txt not found, skipping"; exit 0; fi
+          sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" releases --org "$SENTRY_ORG" new "$REL" || true
+          sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" releases --org "$SENTRY_ORG" files "$REL" upload-sourcemaps --no-rewrite || true
+          sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" releases --org "$SENTRY_ORG" files "$REL" upload "${MAP}" --name "mapping.txt"
+
+      - name: Upload Crashlytics mapping (optional)
+        if: ${{ (inputs.crashlytics_upload || github.event.inputs.crashlytics_upload) == 'true' }}
+        working-directory: ai_buddy_web/android
+        shell: bash
+        run: |
+          set -e
+          chmod +x ./gradlew || true
+          if ./gradlew -q tasks --all | grep -q "uploadCrashlyticsSymbolFileRelease"; then
+            ./gradlew app:uploadCrashlyticsSymbolFileRelease --no-daemon --stacktrace
+          else
+            echo "::warning::Crashlytics task not found; skipping mapping upload"
+          fi
+
+      - name: Save metadata (build number and release notes)
+        id: meta
+        shell: bash
+        env:
+          RN_DISPATCH: ${{ github.event.inputs.release_notes }}
+          RN_CALL: ${{ inputs.release_notes }}
+          BN_DISPATCH: ${{ github.event.inputs.build_number }}
+          BN_CALL: ${{ inputs.build_number }}
+        run: |
+          set -e
+          BN="$BN_DISPATCH"; [ -z "$BN" ] && BN="$BN_CALL"; [ -z "$BN" ] && BN="$GITHUB_RUN_NUMBER"
+          echo "BN=$BN" >> $GITHUB_OUTPUT
+          NOTES="$RN_DISPATCH"; [ -z "$NOTES" ] && NOTES="$RN_CALL"
+          echo "$NOTES" > release_notes.txt
+          echo "RELEASE_NOTES_PATH=$PWD/release_notes.txt" >> $GITHUB_OUTPUT
+
+      - name: Upload release notes artifact
+        if: ${{ steps.meta.outputs.RELEASE_NOTES_PATH != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-notes
+          path: release_notes.txt
+          if-no-files-found: ignore
+
+      - name: Locate AAB
+        id: locate
+        shell: bash
+        run: |
+          set -e
+          CANDIDATES=(
+            "ai_buddy_web/build/app/outputs/bundle/release/app-release.aab"
+            "ai_buddy_web/android/app/build/outputs/bundle/release/app-release.aab"
+          )
+          FOUND=""
+          for p in "${CANDIDATES[@]}"; do
+            if [ -f "$p" ]; then FOUND="$p"; break; fi
+          done
+          if [ -z "$FOUND" ]; then
+            FOUND=$(find ai_buddy_web -type f -name "*.aab" -print -quit || true)
+          fi
+          if [ -z "$FOUND" ]; then
+            echo "::error::AAB not found"; exit 1;
+          fi
+          echo "AAB=$FOUND" >> $GITHUB_OUTPUT
+          ls -lh "$FOUND"
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-aab
+          path: ${{ steps.locate.outputs.AAB }}
+          if-no-files-found: error
+
+    outputs:
+      AAB: ${{ steps.locate.outputs.AAB }}
+
+  upload_play:
+    name: Upload to Google Play
+    runs-on: ubuntu-latest
+    needs: build_aab
+    if: ${{ (github.event.inputs.upload || inputs.upload) == 'true' }}
+    environment: ${{ inputs.environment || github.event.inputs.environment }}
+    steps:
+      - name: Download AAB artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-aab
+          path: dist
+
+      - name: Prepare Play whatsNew files
+        shell: bash
+        env:
+          RN_DISPATCH: ${{ github.event.inputs.release_notes }}
+          RN_CALL: ${{ inputs.release_notes }}
+        run: |
+          set -e
+          NOTES="$RN_DISPATCH"; [ -z "$NOTES" ] && NOTES="$RN_CALL"
+          mkdir -p whatsnew
+          # Default to en-US if not specified; Play requires language files
+          echo "$NOTES" > whatsnew/en-US.txt
+
+      - name: Find AAB path
+        id: find_aab
+        shell: bash
+        run: |
+          set -e
+          FOUND=$(find dist -type f -name "*.aab" -print -quit)
+          if [ -z "$FOUND" ]; then echo "::error::AAB not found in dist"; exit 1; fi
+          echo "AAB=$FOUND" >> $GITHUB_OUTPUT
+          ls -lh "$FOUND"
+
+      - name: Upload to Google Play
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ github.event.inputs.package_name || inputs.package_name }}
+          releaseFiles: ${{ steps.find_aab.outputs.AAB }}
+          track: ${{ github.event.inputs.track || inputs.track }}
+          status: completed
+          whatsNewDirectory: whatsnew

--- a/.github/workflows/ios_release.yml
+++ b/.github/workflows/ios_release.yml
@@ -1,0 +1,415 @@
+name: iOS Release (IPA)
+
+on:
+  workflow_dispatch:
+    inputs:
+      bundle_id:
+        description: "iOS bundle identifier (e.g., app.mhb.preview)"
+        required: false
+        default: "app.mhb.preview"
+      scheme:
+        description: "Xcode scheme"
+        required: false
+        default: "Runner"
+      export_method:
+        description: "Export method (app-store, ad-hoc, development)"
+        required: false
+        default: "app-store"
+      build_number:
+        description: "Build number (optional). Defaults to GitHub run number if empty."
+        required: false
+        default: ""
+      release_notes:
+        description: "Release notes/changelog (optional)"
+        required: false
+        default: ""
+      upload:
+        description: "Upload to TestFlight after build?"
+        required: false
+        default: "false"
+      preflight:
+        description: "Run format/analyze/tests before build?"
+        required: false
+        default: "false"
+      environment:
+        description: "GitHub Environment to run upload job (e.g., beta, production)"
+        required: false
+        default: "beta"
+      sentry_upload:
+        description: "Upload dSYMs to Sentry?"
+        required: false
+        default: "false"
+      sentry_org:
+        description: "Sentry organization slug (if uploading dSYMs)"
+        required: false
+        default: ""
+      sentry_project:
+        description: "Sentry project slug (if uploading dSYMs)"
+        required: false
+        default: ""
+      sentry_release:
+        description: "Sentry release version (defaults to <bundle_id>@<build_number>)"
+        required: false
+        default: ""
+      crashlytics_upload:
+        description: "Upload dSYMs to Firebase Crashlytics?"
+        required: false
+        default: "false"
+  workflow_call:
+    inputs:
+      bundle_id:
+        required: false
+        type: string
+        default: "app.mhb.preview"
+      scheme:
+        required: false
+        type: string
+        default: "Runner"
+      export_method:
+        required: false
+        type: string
+        default: "app-store"
+      build_number:
+        required: false
+        type: string
+        default: ""
+      release_notes:
+        required: false
+        type: string
+        default: ""
+      upload:
+        required: false
+        type: string
+        default: "false"
+      preflight:
+        required: false
+        type: string
+        default: "false"
+      environment:
+        required: false
+        type: string
+        default: "beta"
+      sentry_upload:
+        required: false
+        type: string
+        default: "false"
+      sentry_org:
+        required: false
+        type: string
+        default: ""
+      sentry_project:
+        required: false
+        type: string
+        default: ""
+      sentry_release:
+        required: false
+        type: string
+        default: ""
+      crashlytics_upload:
+        required: false
+        type: string
+        default: "false"
+
+jobs:
+  build_ios:
+    name: Build iOS (IPA or App)
+    runs-on: macos-14
+    env:
+      # Flutter location
+      FLUTTER_VERSION: '3.32.8'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter SDK
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+
+      - name: Flutter version
+        run: flutter --version
+
+      - name: Cache Pub (Dart/Flutter packages)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('ai_buddy_web/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Install Flutter deps
+        working-directory: ai_buddy_web
+        run: flutter pub get
+
+      - name: Preflight - format check
+        if: ${{ (inputs.preflight || github.event.inputs.preflight) == 'true' }}
+        working-directory: ai_buddy_web
+        run: |
+          set -e
+          # Format only relevant Dart sources; exclude backups/exports to keep CI stable
+          FOUND=$(find . -type f -name "*.dart" \
+            -not -path "./lib/screens/quest_screen_backup/*" \
+            -not -path "./lib/screens/quest_screen/*" \
+            -not -path "./lib/dhiwise_export/*" \
+            -not -path "./lib/dhiwise/*" \
+            -not -path "./lib/dhiwise/**/backup/*" -print)
+          if [ -z "$FOUND" ]; then
+            echo "No Dart files to format"; exit 0;
+          fi
+          printf "%s\n" "$FOUND" | tr '\n' '\0' | xargs -0 dart format --output=none --set-exit-if-changed
+
+      - name: Preflight - analyze
+        if: ${{ (inputs.preflight || github.event.inputs.preflight) == 'true' }}
+        working-directory: ai_buddy_web
+        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+
+      - name: Preflight - tests
+        if: ${{ (inputs.preflight || github.event.inputs.preflight) == 'true' }}
+        working-directory: ai_buddy_web
+        run: |
+          if [ -d test ]; then
+            flutter test -r expanded
+          else
+            echo "No tests/ directory found. Skipping flutter test."
+          fi
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cocoapods
+            ai_buddy_web/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ai_buddy_web/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install CocoaPods
+        working-directory: ai_buddy_web/ios
+        run: |
+          set -e
+          pod install --repo-update
+
+      - name: Determine build number
+        id: bn
+        shell: bash
+        env:
+          BN_DISPATCH: ${{ github.event.inputs.build_number }}
+          BN_CALL: ${{ inputs.build_number }}
+        run: |
+          BN="$BN_DISPATCH"; [ -z "$BN" ] && BN="$BN_CALL"; [ -z "$BN" ] && BN="$GITHUB_RUN_NUMBER"
+          echo "bn=$BN" >> $GITHUB_OUTPUT
+
+      - name: Prepare iOS signing (optional)
+        id: signing
+        shell: bash
+        env:
+          IOS_P12_BASE64: ${{ secrets.IOS_P12_BASE64 }}
+          IOS_P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
+          IOS_MOBILEPROVISION_BASE64: ${{ secrets.IOS_MOBILEPROVISION_BASE64 }}
+        run: |
+          set -e
+          if [ -n "$IOS_P12_BASE64" ] && [ -n "$IOS_MOBILEPROVISION_BASE64" ]; then
+            echo "with_signing=true" >> $GITHUB_OUTPUT
+            KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+            KEYCHAIN_PASSWORD=$(uuidgen)
+            security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+            security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+            security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+            echo "$IOS_P12_BASE64" | base64 -d > $RUNNER_TEMP/cert.p12
+            security import $RUNNER_TEMP/cert.p12 -k "$KEYCHAIN_PATH" -P "$IOS_P12_PASSWORD" -T /usr/bin/codesign
+            security list-keychains -s "$KEYCHAIN_PATH" $(security list-keychains -d user | sed 's/\"//g')
+            security find-identity -p codesigning -v || true
+            mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+            echo "$IOS_MOBILEPROVISION_BASE64" | base64 -d > ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
+          else
+            echo "with_signing=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Find dSYMs (if any)
+        id: dsym
+        shell: bash
+        run: |
+          set -e
+          # Common Flutter/Xcode locations
+          DSYM=$(find ai_buddy_web -type d -name "*.dSYM" -print -quit || true)
+          if [ -n "$DSYM" ]; then echo "path=$DSYM" >> $GITHUB_OUTPUT; fi
+
+      - name: Upload dSYMs to Sentry (optional)
+        if: ${{ (inputs.sentry_upload || github.event.inputs.sentry_upload) == 'true' && steps.dsym.outputs.path != '' }}
+        shell: bash
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ inputs.sentry_org || github.event.inputs.sentry_org }}
+          SENTRY_PROJECT: ${{ inputs.sentry_project || github.event.inputs.sentry_project }}
+          BUNDLE_ID: ${{ inputs.bundle_id || github.event.inputs.bundle_id }}
+          BN: ${{ steps.bn.outputs.bn }}
+          SENTRY_RELEASE_INPUT: ${{ inputs.sentry_release || github.event.inputs.sentry_release }}
+        run: |
+          set -e
+          if [ -z "$SENTRY_AUTH_TOKEN" ] || [ -z "$SENTRY_ORG" ] || [ -z "$SENTRY_PROJECT" ]; then
+            echo "::warning::Missing Sentry config; skipping dSYM upload"; exit 0; fi
+          REL="$SENTRY_RELEASE_INPUT"; [ -z "$REL" ] && REL="${BUNDLE_ID}@${BN}"
+          echo "Using Sentry release: $REL"
+          curl -sL https://sentry.io/get-cli/ | bash
+          sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" releases --org "$SENTRY_ORG" new "$REL" || true
+          sentry-cli --auth-token "$SENTRY_AUTH_TOKEN" upload-dif --org "$SENTRY_ORG" --project "$SENTRY_PROJECT" "${{ steps.dsym.outputs.path }}"
+
+      - name: Upload dSYMs to Crashlytics (optional)
+        if: ${{ (inputs.crashlytics_upload || github.event.inputs.crashlytics_upload) == 'true' && steps.dsym.outputs.path != '' }}
+        shell: bash
+        run: |
+          set -e
+          DSYM_PATH="${{ steps.dsym.outputs.path }}"
+          SCRIPT="ai_buddy_web/ios/Pods/FirebaseCrashlytics/upload-symbols"
+          GSP1="ai_buddy_web/ios/Runner/GoogleService-Info.plist"
+          GSP2="ai_buddy_web/ios/GoogleService-Info.plist"
+          if [ ! -f "$SCRIPT" ]; then echo "::warning::Crashlytics upload-symbols script not found; skipping"; exit 0; fi
+          GSP=""
+          [ -f "$GSP1" ] && GSP="$GSP1"
+          [ -z "$GSP" ] && [ -f "$GSP2" ] && GSP="$GSP2"
+          if [ -z "$GSP" ]; then echo "::warning::GoogleService-Info.plist not found; skipping Crashlytics upload"; exit 0; fi
+          chmod +x "$SCRIPT" || true
+          echo "Uploading dSYM to Crashlytics using $SCRIPT and $GSP"
+          bash "$SCRIPT" -gsp "$GSP" -p ios "$DSYM_PATH"
+
+      - name: Build (signed IPA when signing available; else unsigned app)
+        working-directory: ai_buddy_web
+        env:
+          EXPORT_METHOD: ${{ inputs.export_method || github.event.inputs.export_method }}
+        run: |
+          set -e
+          BN="${{ steps.bn.outputs.bn }}"
+          echo "Using build number: $BN"
+          if [ "${{ steps.signing.outputs.with_signing }}" = "true" ]; then
+            flutter build ipa --export-method "$EXPORT_METHOD" --build-number "$BN"
+          else
+            flutter build ios --release --no-codesign --build-number "$BN"
+          fi
+
+      - name: Locate artifact
+        id: locate
+        shell: bash
+        run: |
+          set -e
+          IPA=$(find ai_buddy_web -type f -name "*.ipa" -print -quit || true)
+          APP=$(find ai_buddy_web/build/ios/iphoneos -type d -name "*.app" -print -quit || true)
+          if [ -n "$IPA" ]; then
+            echo "type=ipa" >> $GITHUB_OUTPUT
+            echo "path=$IPA" >> $GITHUB_OUTPUT
+          elif [ -n "$APP" ]; then
+            echo "type=app" >> $GITHUB_OUTPUT
+            echo "path=$APP" >> $GITHUB_OUTPUT
+          else
+            echo "::error::No IPA or .app found"; exit 1
+          fi
+
+      - name: Package .app (if unsigned)
+        id: package
+        if: ${{ steps.locate.outputs.type == 'app' }}
+        shell: bash
+        run: |
+          set -e
+          cd "$(dirname '${{ steps.locate.outputs.path }}')"
+          APPNAME=$(basename "${{ steps.locate.outputs.path }}")
+          zip -r "$APPNAME.zip" "$APPNAME"
+          echo "zip_path=$(pwd)/$APPNAME.zip" >> $GITHUB_OUTPUT
+
+      - name: Upload IPA artifact
+        if: ${{ steps.locate.outputs.type == 'ipa' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: ${{ steps.locate.outputs.path }}
+          if-no-files-found: error
+
+      - name: Upload unsigned app artifact (zipped)
+        if: ${{ steps.locate.outputs.type == 'app' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-app
+          path: ${{ steps.package.outputs.zip_path }}
+          if-no-files-found: error
+
+      - name: Save release notes
+        id: rn
+        shell: bash
+        env:
+          RN_DISPATCH: ${{ github.event.inputs.release_notes }}
+          RN_CALL: ${{ inputs.release_notes }}
+        run: |
+          set -e
+          NOTES="$RN_DISPATCH"; [ -z "$NOTES" ] && NOTES="$RN_CALL"
+          echo "$NOTES" > release_notes.txt
+          echo "path=$PWD/release_notes.txt" >> $GITHUB_OUTPUT
+
+      - name: Upload release notes artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-release-notes
+          path: release_notes.txt
+          if-no-files-found: ignore
+
+    outputs:
+      ARTIFACT_TYPE: ${{ steps.locate.outputs.type }}
+      ARTIFACT_PATH: ${{ steps.locate.outputs.path }}
+
+  upload_testflight:
+    name: Upload to TestFlight
+    runs-on: macos-14
+    needs: build_ios
+    if: ${{ (github.event.inputs.upload || inputs.upload) == 'true' && needs.build_ios.outputs.ARTIFACT_TYPE == 'ipa' }}
+    environment: ${{ inputs.environment || github.event.inputs.environment }}
+    steps:
+      - name: Download IPA artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-ipa
+          path: dist
+
+      - name: Find IPA
+        id: find
+        shell: bash
+        run: |
+          set -e
+          IPA=$(find dist -type f -name "*.ipa" -print -quit)
+          if [ -z "$IPA" ]; then echo "::error::IPA not found in dist"; exit 1; fi
+          echo "ipa=$IPA" >> $GITHUB_OUTPUT
+
+      - name: Create App Store Connect API key file
+        id: apikey
+        shell: bash
+        env:
+          KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          PRIVATE_KEY_B64: ${{ secrets.APPSTORE_API_PRIVATE_KEY_BASE64 }}
+        run: |
+          set -e
+          if [ -z "$KEY_ID" ] || [ -z "$ISSUER_ID" ] || [ -z "$PRIVATE_KEY_B64" ]; then
+            echo "::error::Missing App Store Connect API key secrets"; exit 1;
+          fi
+          echo "$PRIVATE_KEY_B64" | base64 -d > api_key.p8
+          cat > api_key.json <<EOF
+          {
+            "key_id": "$KEY_ID",
+            "issuer_id": "$ISSUER_ID",
+            "key": "$(sed 's/\n/\\n/g' api_key.p8)",
+            "in_house": false
+          }
+          EOF
+
+      - name: Upload via Fastlane Pilot
+        env:
+          FASTLANE_DISABLE_COLORS: 1
+          RN_DISPATCH: ${{ github.event.inputs.release_notes }}
+          RN_CALL: ${{ inputs.release_notes }}
+        run: |
+          set -e
+          NOTES="$RN_DISPATCH"; [ -z "$NOTES" ] && NOTES="$RN_CALL"
+          gem list -i fastlane || sudo gem install fastlane --no-document
+          fastlane pilot upload \
+            --api_key_path api_key.json \
+            --ipa "${{ steps.find.outputs.ipa }}" \
+            --skip_waiting_for_build_processing true \
+            --changelog "$NOTES"

--- a/.github/workflows/mobile_release.yml
+++ b/.github/workflows/mobile_release.yml
@@ -1,0 +1,189 @@
+name: Mobile Release (Android + iOS)
+
+on:
+  workflow_dispatch:
+    inputs:
+      app_id:
+        description: "Android applicationId override (optional)"
+        required: false
+        default: "app.mhb.preview"
+      package_name:
+        description: "Google Play package name (e.g., app.mhb.preview)"
+        required: false
+        default: "app.mhb.preview"
+      android_track:
+        description: "Android Play track (internal, alpha, beta, production)"
+        required: false
+        default: "internal"
+      ios_bundle_id:
+        description: "iOS bundle identifier"
+        required: false
+        default: "app.mhb.preview"
+      ios_scheme:
+        description: "Xcode scheme"
+        required: false
+        default: "Runner"
+      ios_export_method:
+        description: "iOS export method (app-store, ad-hoc, development)"
+        required: false
+        default: "app-store"
+      build_number:
+        description: "Unified build number for both platforms (optional). Defaults to run number if empty."
+        required: false
+        default: ""
+      release_notes:
+        description: "Unified release notes/changelog (optional)"
+        required: false
+        default: ""
+      preflight:
+        description: "Run format/analyze/tests before builds?"
+        required: false
+        default: "false"
+      upload_android:
+        description: "Upload Android to Google Play after build?"
+        required: false
+        default: "false"
+      upload_ios:
+        description: "Upload iOS to TestFlight after build?"
+        required: false
+        default: "false"
+      environment:
+        description: "GitHub Environment for upload jobs (beta, production)"
+        required: false
+        default: "beta"
+      sentry_upload:
+        description: "Upload symbols to Sentry for both platforms?"
+        required: false
+        default: "false"
+      sentry_org:
+        description: "Sentry organization slug"
+        required: false
+        default: ""
+      sentry_project_android:
+        description: "Sentry project slug for Android"
+        required: false
+        default: ""
+      sentry_project_ios:
+        description: "Sentry project slug for iOS"
+        required: false
+        default: ""
+      sentry_release:
+        description: "Sentry release version override"
+        required: false
+        default: ""
+      create_gh_release:
+        description: "Create a GitHub Release and attach artifacts?"
+        required: false
+        default: "false"
+      tag_prefix:
+        description: "Tag prefix for GitHub Release (e.g., mobile-v)"
+        required: false
+        default: "mobile-v"
+      notify_slack:
+        description: "Send a Slack notification (requires SLACK_WEBHOOK_URL secret)"
+        required: false
+        default: "false"
+      crashlytics_upload:
+        description: "Upload Android Crashlytics symbols (if Gradle task available)"
+        required: false
+        default: "false"
+
+jobs:
+  android:
+    name: Android job
+    uses: ./.github/workflows/android_release.yml
+    secrets: inherit
+    with:
+      app_id: ${{ inputs.app_id }}
+      package_name: ${{ inputs.package_name }}
+      track: ${{ inputs.android_track }}
+      build_number: ${{ inputs.build_number }}
+      release_notes: ${{ inputs.release_notes }}
+      upload: ${{ inputs.upload_android }}
+      preflight: ${{ inputs.preflight }}
+      environment: ${{ inputs.environment }}
+      sentry_upload: ${{ inputs.sentry_upload }}
+      sentry_org: ${{ inputs.sentry_org }}
+      sentry_project: ${{ inputs.sentry_project_android }}
+      sentry_release: ${{ inputs.sentry_release }}
+      crashlytics_upload: ${{ inputs.crashlytics_upload }}
+
+  ios:
+    name: iOS job
+    uses: ./.github/workflows/ios_release.yml
+    secrets: inherit
+    with:
+      bundle_id: ${{ inputs.ios_bundle_id }}
+      scheme: ${{ inputs.ios_scheme }}
+      export_method: ${{ inputs.ios_export_method }}
+      build_number: ${{ inputs.build_number }}
+      release_notes: ${{ inputs.release_notes }}
+      upload: ${{ inputs.upload_ios }}
+      preflight: ${{ inputs.preflight }}
+      environment: ${{ inputs.environment }}
+      sentry_upload: ${{ inputs.sentry_upload }}
+      sentry_org: ${{ inputs.sentry_org }}
+      sentry_project: ${{ inputs.sentry_project_ios }}
+      sentry_release: ${{ inputs.sentry_release }}
+      crashlytics_upload: ${{ inputs.crashlytics_upload }}
+
+  release_notify:
+    name: Release and Notify
+    runs-on: ubuntu-latest
+    needs: [android, ios]
+    if: ${{ inputs.create_gh_release == 'true' || inputs.notify_slack == 'true' }}
+    steps:
+      - name: Download Android artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-aab
+          path: dist
+        continue-on-error: true
+
+      - name: Download iOS IPA artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ios-ipa
+          path: dist
+        continue-on-error: true
+
+      - name: Compose tag and body
+        id: meta
+        shell: bash
+        env:
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+          BN: ${{ inputs.build_number }}
+          RN: ${{ inputs.release_notes }}
+        run: |
+          set -e
+          BNV="$BN"; [ -z "$BNV" ] && BNV="$GITHUB_RUN_NUMBER"
+          TAG="${TAG_PREFIX}${BNV}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "$RN" > RELEASE_BODY.txt
+          echo "body_path=$PWD/RELEASE_BODY.txt" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        if: ${{ inputs.create_gh_release == 'true' }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.tag }}
+          body_path: ${{ steps.meta.outputs.body_path }}
+          files: |
+            dist/*.aab
+            dist/*.ipa
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Slack notify
+        if: ${{ inputs.notify_slack == 'true' }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -e
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then echo "::warning::SLACK_WEBHOOK_URL not set, skipping"; exit 0; fi
+          ANDROID_PRESENT=$(ls dist/*.aab 2>/dev/null | wc -l | xargs)
+          IOS_PRESENT=$(ls dist/*.ipa 2>/dev/null | wc -l | xargs)
+          MSG="Mobile build completed. Android artifact: $ANDROID_PRESENT, iOS artifact: $IOS_PRESENT. Tag: ${{ steps.meta.outputs.tag }}"
+          PAYLOAD=$(printf '{"text":"%s"}' "${MSG//"/\"}")
+          curl -X POST -H 'Content-type: application/json' --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
1. Adds new workflows in .github/workflows/:

- mobile_release.yml(aggregator)
- android_release.yml
- ios_release.yml

2. Preflight checks: format/analyze/tests (non-fatal infos/warnings; tests only if test/ exists)
3. Uploads are opt-in via inputs (default off). No secrets used by default.
4. Goal: enable manual, safe mobile builds via Actions.